### PR TITLE
Add Docker Swarm support

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,37 @@ Script for monitoring docker compose project
 - **docker_project_discovery.sh**: Performs discovery of Compose projects
 - **compose_status.sh**: Creates items with the status of Compose projects.
 
+### Project grouping: Swarm support and custom override
+
+Discovery works out of the box on both Docker Compose and Docker Swarm. On Compose nodes containers are grouped by the standard `com.docker.compose.project` label; on Swarm nodes they are grouped by `com.docker.stack.namespace`, the label that Swarm assigns automatically to every container of a stack. No configuration is required for either case.
+
+In addition, a container can opt into a custom grouping by setting the `zabbix.docker.project` label. When present, this label takes precedence over the auto-detected one. This is useful to split a single project (Compose or Swarm) into multiple logical sub-projects, or to merge containers from different projects into the same bucket by giving them the same value.
+
+Containers that carry none of these labels continue to fall into the `no-docker-compose-project` bucket as before.
+
+Priority order (first non-empty match wins):
+1. `zabbix.docker.project` — opt-in custom label
+2. `com.docker.compose.project` — Docker Compose default
+3. `com.docker.stack.namespace` — Docker Swarm default
+4. `no-docker-compose-project` — fallback bucket (unchanged)
+
+Example — split a compose project into two logical sub-projects:
+
+```yaml
+services:
+  api:
+    labels:
+      zabbix.docker.project: "myapp-backend"
+  db:
+    labels:
+      zabbix.docker.project: "myapp-data"
+  redis:
+    labels:
+      zabbix.docker.project: "myapp-data"
+```
+
+Zabbix will discover two separate projects (`myapp-backend`, `myapp-data`) instead of a single aggregate.
+
 # Template files
 
 The template directory contains the templates related to the scripts to be added to Zabbix:

--- a/bin/docker/compose_container_discovery.py
+++ b/bin/docker/compose_container_discovery.py
@@ -1,18 +1,13 @@
 import subprocess
 import json
 
-from project_grouping import resolve_project
+from project_grouping import resolve_project, inspect_container
 
 
 def get_container_ids():
     result = subprocess.run(['docker', 'ps', '-a', '--format', '{{.ID}}'],
                             capture_output=True, text=True)
     return result.stdout.strip().splitlines()
-
-def inspect_container(container_id):
-    result = subprocess.run(['docker', 'inspect', container_id],
-                            capture_output=True, text=True)
-    return json.loads(result.stdout)[0]
 
 def extract_info(container_data):
     name = container_data['Name'].lstrip('/')
@@ -38,6 +33,8 @@ def main():
     containers_info = []
     for container_id in get_container_ids():
         container_data = inspect_container(container_id)
+        if container_data is None:
+            continue
         info = extract_info(container_data)
         containers_info.append(info)
 

--- a/bin/docker/compose_container_discovery.py
+++ b/bin/docker/compose_container_discovery.py
@@ -1,6 +1,9 @@
 import subprocess
 import json
 
+from project_grouping import resolve_project
+
+
 def get_container_ids():
     result = subprocess.run(['docker', 'ps', '-a', '--format', '{{.ID}}'],
                             capture_output=True, text=True)
@@ -14,7 +17,8 @@ def inspect_container(container_id):
 def extract_info(container_data):
     name = container_data['Name'].lstrip('/')
     labels = container_data['Config'].get('Labels', {})
-    project = labels.get('com.docker.compose.project', 'no-docker-compose-project')
+    # Use priority chain: custom label > compose project > swarm namespace > fallback bucket.
+    project = resolve_project(labels)
 
     state = container_data['State']['Status']
     health_info = container_data['State'].get('Health', {})

--- a/bin/docker/compose_status.py
+++ b/bin/docker/compose_status.py
@@ -2,6 +2,9 @@ import subprocess
 import json
 import sys
 
+from project_grouping import resolve_project
+
+
 def get_containers():
     result = subprocess.run(['docker', 'ps', '-a', '-q'], capture_output=True, text=True)
     return result.stdout.strip().splitlines()
@@ -19,7 +22,8 @@ def main(project):
     for container_id in get_containers():
         container = inspect_container(container_id)
         labels = container.get('Config', {}).get('Labels', {})
-        proj = labels.get('com.docker.compose.project', 'no-docker-compose-project')
+        # Use priority chain: custom label > compose project > fallback bucket.
+        proj = resolve_project(labels)
         state = container.get('State', {}).get('Status', 'unknown')
 
         if proj == project:

--- a/bin/docker/compose_status.py
+++ b/bin/docker/compose_status.py
@@ -2,16 +2,12 @@ import subprocess
 import json
 import sys
 
-from project_grouping import resolve_project
+from project_grouping import resolve_project, inspect_container
 
 
 def get_containers():
     result = subprocess.run(['docker', 'ps', '-a', '-q'], capture_output=True, text=True)
     return result.stdout.strip().splitlines()
-
-def inspect_container(container_id):
-    result = subprocess.run(['docker', 'inspect', container_id], capture_output=True, text=True)
-    return json.loads(result.stdout)[0]
 
 def main(project):
     found = False
@@ -21,6 +17,8 @@ def main(project):
 
     for container_id in get_containers():
         container = inspect_container(container_id)
+        if container is None:
+            continue
         labels = container.get('Config', {}).get('Labels', {})
         # Use priority chain: custom label > compose project > fallback bucket.
         proj = resolve_project(labels)

--- a/bin/docker/docker_project_discovery.py
+++ b/bin/docker/docker_project_discovery.py
@@ -2,6 +2,9 @@ import subprocess
 import json
 from collections import defaultdict
 
+from project_grouping import resolve_project
+
+
 def get_container_ids():
     result = subprocess.run(['docker', 'ps', '-a', '--format', '{{.ID}}'],
                             capture_output=True, text=True)
@@ -19,7 +22,8 @@ def main():
         container_data = inspect_container(container_id)
         name = container_data['Name'].lstrip('/')
         labels = container_data['Config'].get('Labels', {})
-        project = labels.get('com.docker.compose.project', 'no-docker-compose-project')
+        # Use priority chain: custom label > compose project > fallback bucket.
+        project = resolve_project(labels)
         state = container_data['State']['Status']
         project_states[project].append(state)
 

--- a/bin/docker/docker_project_discovery.py
+++ b/bin/docker/docker_project_discovery.py
@@ -2,7 +2,7 @@ import subprocess
 import json
 from collections import defaultdict
 
-from project_grouping import resolve_project
+from project_grouping import resolve_project, inspect_container
 
 
 def get_container_ids():
@@ -10,16 +10,13 @@ def get_container_ids():
                             capture_output=True, text=True)
     return result.stdout.strip().splitlines()
 
-def inspect_container(container_id):
-    result = subprocess.run(['docker', 'inspect', container_id],
-                            capture_output=True, text=True)
-    return json.loads(result.stdout)[0]
-
 def main():
     project_states = defaultdict(list)
 
     for container_id in get_container_ids():
         container_data = inspect_container(container_id)
+        if container_data is None:
+            continue
         name = container_data['Name'].lstrip('/')
         labels = container_data['Config'].get('Labels', {})
         # Use priority chain: custom label > compose project > fallback bucket.

--- a/bin/docker/docker_project_discovery.py
+++ b/bin/docker/docker_project_discovery.py
@@ -2,7 +2,7 @@ import subprocess
 import json
 from collections import defaultdict
 
-from project_grouping import resolve_project, inspect_container
+from project_grouping import resolve_project, resolve_runtime, inspect_container
 
 
 def get_container_ids():
@@ -12,17 +12,18 @@ def get_container_ids():
 
 def main():
     project_states = defaultdict(list)
+    project_runtime = {}
 
     for container_id in get_container_ids():
         container_data = inspect_container(container_id)
         if container_data is None:
             continue
-        name = container_data['Name'].lstrip('/')
         labels = container_data['Config'].get('Labels', {})
-        # Use priority chain: custom label > compose project > fallback bucket.
         project = resolve_project(labels)
         state = container_data['State']['Status']
         project_states[project].append(state)
+        if project not in project_runtime:
+            project_runtime[project] = resolve_runtime(labels)
 
     summary = []
 
@@ -39,7 +40,8 @@ def main():
 
         summary.append({
             "{#PROJECT}": project,
-            "{#STATUS}": status
+            "{#STATUS}": status,
+            "{#RUNTIME}": project_runtime[project]
         })
 
     print(json.dumps(summary, indent=2))

--- a/bin/docker/project_grouping.py
+++ b/bin/docker/project_grouping.py
@@ -1,8 +1,21 @@
-"""Shared helper to resolve the project bucket a container belongs to.
+"""Shared helpers for Docker container discovery scripts.
 
-Used by both docker_project_discovery.py and compose_status.py so the
-priority chain is defined in a single place.
+Used by docker_project_discovery.py, compose_status.py and
+compose_container_discovery.py so common logic is defined in a single place.
 """
+
+import subprocess
+import json
+
+
+def inspect_container(container_id):
+    result = subprocess.run(['docker', 'inspect', container_id],
+                            capture_output=True, text=True)
+    # Docker CLI itself can fail to inspect the container.
+    # Prevent crashing in case of empty container data (e.g. a dead container).
+    if result.returncode != 0:
+        return None
+    return json.loads(result.stdout)[0]
 
 
 def resolve_project(labels):

--- a/bin/docker/project_grouping.py
+++ b/bin/docker/project_grouping.py
@@ -1,0 +1,30 @@
+"""Shared helper to resolve the project bucket a container belongs to.
+
+Used by both docker_project_discovery.py and compose_status.py so the
+priority chain is defined in a single place.
+"""
+
+
+def resolve_project(labels):
+    """Resolve the project bucket a container belongs to.
+
+    Priority order (first non-empty match wins):
+      1. zabbix.docker.project      - opt-in custom label for explicit grouping
+      2. com.docker.compose.project - Docker Compose default label
+      3. com.docker.stack.namespace - Docker Swarm default label (stack name)
+      4. 'no-docker-compose-project' - fallback bucket for unlabeled containers
+
+    The custom label lets users override the auto-detected grouping,
+    which is useful to split a project into logical sub-projects or
+    to merge standalone containers under a shared bucket.
+
+    Including the Swarm namespace makes the discovery work out of the
+    box on Swarm nodes, where containers carry com.docker.stack.namespace
+    instead of com.docker.compose.project.
+    """
+    return (
+        labels.get('zabbix.docker.project')
+        or labels.get('com.docker.compose.project')
+        or labels.get('com.docker.stack.namespace')
+        or 'no-docker-compose-project'
+    )

--- a/bin/docker/project_grouping.py
+++ b/bin/docker/project_grouping.py
@@ -41,3 +41,17 @@ def resolve_project(labels):
         or labels.get('com.docker.stack.namespace')
         or 'no-docker-compose-project'
     )
+
+
+def resolve_runtime(labels):
+    """Detect the container runtime environment.
+
+    Returns 'swarm', 'compose', or 'standalone'.
+    Independent of resolve_project: runtime is about infrastructure,
+    project is about grouping.
+    """
+    if labels.get('com.docker.stack.namespace'):
+        return 'swarm'
+    if labels.get('com.docker.compose.project'):
+        return 'compose'
+    return 'standalone'

--- a/templates/zbx_topix_docker_compose_status.xml
+++ b/templates/zbx_topix_docker_compose_status.xml
@@ -36,6 +36,10 @@
                   <tag>project status</tag>
                   <value>{#PROJECT}</value>
                 </tag>
+                <tag>
+                  <tag>runtime</tag>
+                  <value>{#RUNTIME}</value>
+                </tag>
               </tags>
             </item_prototype>
           </item_prototypes>


### PR DESCRIPTION
## Summary

- Add Docker Swarm support via a label priority chain that groups containers by `zabbix.docker.project` (custom override), `com.docker.compose.project` (Compose), or `com.docker.stack.namespace` (Swarm)
- Centralize shared logic (`resolve_project`, `resolve_runtime`, `inspect_container`) in `project_grouping.py` to avoid duplication across scripts
- Handle dead/removed containers gracefully by checking `docker inspect` exit code before parsing
- Add `{#RUNTIME}` property (swarm/compose/standalone) to project discovery, exposed as a tag in the template for runtime-aware alert configuration

## Tested on

- Ubuntu 24.04, Zabbix Agent 2 v7.4.9, Docker 29.1.5
- Mixed environment: Docker Swarm stacks + Docker Compose standalone projects
- Validated via Zabbix 7.4 server: LLD discovery, project status items, custom label override, runtime tags

## Backward compatibility

- Existing Compose-only environments are unaffected: the priority chain falls through to `com.docker.compose.project` as before
- The `no-docker-compose-project` fallback bucket is preserved
- The `{#RUNTIME}` tag renders as empty string on hosts running older script versions — no breakage